### PR TITLE
Fix drawer content getting clipped on mobile

### DIFF
--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -1041,7 +1041,7 @@ const mainDivPaddingStyle = computed(() => {
         </div>
       </DrawerTrigger>
       <DrawerContent
-        class="flex max-h-[90vh] flex-col items-center justify-between overflow-y-auto overflow-x-hidden"
+        class="flex flex-col items-center justify-between overflow-y-auto overflow-x-hidden"
       >
         <div class="flex grow flex-col items-center justify-center gap-4 p-4">
           <DrawerTitle>{{ t('Export') }}</DrawerTitle>


### PR DESCRIPTION
Removed max-height constraint from QRCodeCreate drawer content

This PR removes the `max-h-[90vh]` class from the DrawerContent component in QRCodeCreate.vue, allowing the drawer to use its default height behavior instead of being constrained to 90% of the viewport height.