### PR TITLE
Improve copy on MiniQR

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -63,7 +63,7 @@
   "Loaded from file": "Loaded from file",
   "Copy QR Code to clipboard": "Copy QR Code to clipboard",
   "Right click the image, and select 'Copy Image'": "Right click the image, and select 'Copy Image'",
-  "Export as": "Export as",
+  "Export QR code": "Export QR code",
   "Download QR Code as PNG": "Download QR Code as PNG",
   "Download QR Code as SVG": "Download QR Code as SVG",
   "Download QR Code as JPG": "Download QR Code as JPG",
@@ -293,9 +293,8 @@
   "Created by": "Created by",
   "Toggle dark mode": "Toggle dark mode",
   "Open data type generator": "Open data type generator",
-  "Data:": "Data:",
-  "Frame text:": "Frame text:",
-  "File name:": "File name:",
+  "Data": "Data",
+  "File name": "File name",
   "Paste": "Paste",
   "Settings to customize your QR code": "Settings to customize your QR code"
 }

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -1044,7 +1044,7 @@ const mainDivPaddingStyle = computed(() => {
         class="flex max-h-[90vh] flex-col items-center justify-between overflow-y-auto overflow-x-hidden"
       >
         <div class="flex grow flex-col items-center justify-center gap-4 p-4">
-          <DrawerTitle>{{ t('Export') }}</DrawerTitle>
+          <DrawerTitle>{{ t('Export QR code') }}</DrawerTitle>
           <div ref="mainContentContainer" id="main-content-container" class="w-full"></div>
         </div>
       </DrawerContent>
@@ -1194,7 +1194,7 @@ const mainDivPaddingStyle = computed(() => {
             </button>
           </div>
           <div id="export-options" class="grid place-items-center gap-4">
-            <p class="text-zinc-900 dark:text-zinc-100">{{ t('Export as') }}</p>
+            <p class="text-zinc-900 dark:text-zinc-100">{{ t('Export QR code') }}</p>
             <div class="flex flex-row items-center justify-center gap-2">
               <button
                 id="download-qr-image-button-png"
@@ -1604,7 +1604,7 @@ const mainDivPaddingStyle = computed(() => {
                                   <div class="flex flex-col gap-1">
                                     <span
                                       class="text-xs font-medium text-gray-500 dark:text-gray-400"
-                                      >{{ $t('Data:') }}</span
+                                      >{{ $t('Data') }}</span
                                     >
                                     <code
                                       class="rounded bg-white px-2 py-1 font-mono text-sm dark:bg-gray-900"


### PR DESCRIPTION
# Update QR Code Export UI Text

This PR updates the text in the QR code export interface to improve clarity and consistency:

- Changed "Export as" to "Export QR code" in both the drawer title and export options section
- Simplified "Data:" to "Data" by removing the colon
- Removed "Frame text:" label entirely
- Changed "File name:" to "File name" by removing the colon

These changes make the UI language more concise and consistent throughout the application.