### PR TITLE
Fix mobile drawer height issues 

### DIFF
--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -11,7 +11,13 @@ import {
   AccordionTrigger
 } from '@/components/ui/accordion'
 import { Combobox } from '@/components/ui/Combobox'
-import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger
+} from '@/components/ui/drawer'
 import VCardPreview from '@/components/VCardPreview.vue'
 import { IS_COPY_IMAGE_TO_CLIPBOARD_SUPPORTED } from '@/utils/clipboard'
 import { createRandomColor, getRandomItemInArray } from '@/utils/color'
@@ -890,54 +896,11 @@ const updateDataFromModal = (newData: string) => {
   // Optionally trigger QR code regeneration here if needed
 }
 // #endregion
-
-//#region /* Dynamic padding for mobile drawer */
-const drawerTriggerHeight = ref(0)
-const BUFFER_PADDING = 20 // Extra space below the drawer trigger
-
-function updateDrawerTriggerHeight() {
-  nextTick(() => {
-    const el = document.getElementById('drawer-preview-container')
-    if (el) {
-      drawerTriggerHeight.value = el.offsetHeight
-    } else {
-      drawerTriggerHeight.value = 0 // Fallback if element not found
-    }
-  })
-}
-
-watch(
-  isLarge,
-  (newIsLarge) => {
-    if (!newIsLarge) {
-      updateDrawerTriggerHeight() // Drawer is now visible
-    } else {
-      drawerTriggerHeight.value = 0 // Drawer is hidden, reset padding effect
-    }
-  },
-  { immediate: true } // Run on initial load
-)
-
-// Watch for changes that might affect the drawer trigger's height
-watch(showFrame, () => {
-  if (!isLarge.value) {
-    updateDrawerTriggerHeight()
-  }
-})
-
-const mainDivPaddingStyle = computed(() => {
-  if (!isLarge.value && drawerTriggerHeight.value > 0) {
-    return { paddingBottom: `${drawerTriggerHeight.value + BUFFER_PADDING}px` }
-  }
-  return { paddingBottom: '0px' } // Default for large screens or if height is 0
-})
-//#endregion
 </script>
 
 <template>
   <div
     class="flex items-start justify-center gap-4 overflow-x-hidden md:flex-row md:gap-6 lg:gap-12 lg:pb-0"
-    :style="mainDivPaddingStyle"
   >
     <!-- Sticky sidebar on large screens -->
     <div
@@ -1039,11 +1002,11 @@ const mainDivPaddingStyle = computed(() => {
           </div>
         </div>
       </DrawerTrigger>
-      <DrawerContent
-        class="flex flex-col items-center justify-between overflow-y-auto overflow-x-hidden"
-      >
-        <div class="flex grow flex-col items-center justify-center gap-4 p-4">
+      <DrawerContent>
+        <DrawerHeader>
           <DrawerTitle>{{ t('Export QR code') }}</DrawerTitle>
+        </DrawerHeader>
+        <div class="overflow-y-auto overflow-x-hidden px-4 pb-4">
           <div ref="mainContentContainer" id="main-content-container" class="w-full"></div>
         </div>
       </DrawerContent>

--- a/src/components/ui/drawer/DrawerContent.vue
+++ b/src/components/ui/drawer/DrawerContent.vue
@@ -19,7 +19,7 @@ const forwarded = useForwardPropsEmits(props, emits)
       v-bind="forwarded"
       :class="
         cn(
-          'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
+          'fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[96vh] flex-col rounded-t-[10px] border bg-background',
           props.class
         )
       "


### PR DESCRIPTION
### What changed?

- Improved the QR code drawer component:
  - Added proper DrawerHeader component
  - Improved layout and scrolling behavior in the drawer
  - Removed complex dynamic padding calculation logic
  - Set max-height for the drawer content to 96vh to prevent overflow

### How to test?

1. Open the QR code creation page on a mobile device or in responsive mode
2. Click on the drawer trigger to open the export drawer
3. Verify that the drawer opens properly with correct layout
4. Check that scrolling works as expected within the drawer content
5. Ensure the drawer doesn't overflow the viewport

### Why make this change?

The previous implementation of the drawer had issues with layout and scrolling on mobile devices. The complex padding calculation was unnecessary and potentially causing layout problems.